### PR TITLE
Fix 2025.3.1

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/android/myapplication/Adapter/IbsFixtureAdapter.kt
+++ b/app/src/main/java/com/android/myapplication/Adapter/IbsFixtureAdapter.kt
@@ -1,24 +1,30 @@
 package com.android.myapplication.Adapter
 
+import android.content.Context
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.android.myapplication.Data.Mc
 import com.android.myapplication.Data.Mc2
 import com.android.myapplication.R
 import com.android.myapplication.databinding.FragmentFixtureItemBinding
 
-class IbsFixtureAdapter(private val onItemClick: (Mc2.ResultData.Result) -> Unit) :
+class IbsFixtureAdapter(
+    private val onItemClick: (Mc2.ResultData.Result) -> Unit?,
+    val items:  MutableList<Mc2.ResultData.Result>
+) :
     RecyclerView.Adapter<IbsFixtureAdapter.ViewHolder>() {
 
-    private var items = mutableListOf<Mc2.ResultData.Result>()
 
     fun setItems(items: List<Mc2.ResultData.Result>) {
         Log.d("setItems", "Ibs Fixture 의 Adapter updated, new size: ${items.size}")
+
         this.items.clear()
         this.items.addAll(items.filter { it.category == "1" })
         notifyDataSetChanged()
+
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/java/com/android/myapplication/Adapter/OsstemAbutmentAdapter.kt
+++ b/app/src/main/java/com/android/myapplication/Adapter/OsstemAbutmentAdapter.kt
@@ -9,7 +9,9 @@ import com.android.myapplication.Data.Mc2
 import com.android.myapplication.R
 import com.android.myapplication.databinding.FragmentFixtureItemBinding
 
-class OsstemAbutmentAdapter(private val onItemClick: (Mc2.ResultData.Result) -> Unit) :
+class OsstemAbutmentAdapter(
+    private val onItemClick: (Mc2.ResultData.Result) -> Unit
+) :
     RecyclerView.Adapter<OsstemAbutmentAdapter.ViewHolder>() {
 
     private var items = mutableListOf<Mc2.ResultData.Result>()

--- a/app/src/main/java/com/android/myapplication/InventoryViewModel.kt
+++ b/app/src/main/java/com/android/myapplication/InventoryViewModel.kt
@@ -14,20 +14,14 @@ import retrofit2.Response
 class InventoryViewModel : ViewModel() {
     //commit test
     private val _items = MutableLiveData<List<Mc2.ResultData.Result>>()
-    val items: LiveData<List<Mc2.ResultData.Result>> get() = _items
-
-    private var allItems: List<Mc2.ResultData.Result> = emptyList()
-
-    fun setAllItems(items: List<Mc2.ResultData.Result>) {
-        allItems = items
-        _items.postValue(items.toList()) // 🚀 postValue() 사용
-    }
+    val items: LiveData<List<Mc2.ResultData.Result>>
+        get() = _items
 
 
     fun getMcData() {
         val service = RetrofitModule.createSonnyApiService()
         val call: Call<Mc2> = service.getMcdata()
-//        Log.e("getMcData", ">>>>>>>>>>getMcData() 호출!!")
+
         call.enqueue(object : Callback<Mc2> {
             override fun onResponse(call: Call<Mc2>, response: Response<Mc2>) {
                 if (response.isSuccessful) {
@@ -35,8 +29,9 @@ class InventoryViewModel : ViewModel() {
                     val resultList =
                         responseBody?.resultData?.result?.filterNotNull() ?: emptyList()
 
-                    setAllItems(resultList)
-//                    Log.d("InventoryViewModel", "API Response: ${responseBody?.resultData?.result} items")
+                    _items.value = resultList!!
+                    Log.d("InventoryViewModel", "getMcData()가 호출됨")
+
                 }
             }
 
@@ -54,6 +49,7 @@ class InventoryViewModel : ViewModel() {
             override fun onResponse(call: Call<Void>, response: Response<Void>) {
                 if (response.isSuccessful) {
                     Log.d("InventoryViewModel", "Item updated successfully!")
+
                     // 데이터를 다시 불러와서 LiveData에 업데이트
                     getMcData()
 
@@ -68,5 +64,4 @@ class InventoryViewModel : ViewModel() {
         })
     }
 }
-//변경1
 


### PR DESCRIPTION
Dialog Fragment

📌 IllegalStateException: Can't access ViewModels from detached fragment 오류 원인
오류 메시지를 보면 Fragment가 분리(detached)된 상태에서 ViewModel에 접근하려고 해서 발생한 문제

즉, bgCody 버튼을 눌렀을 때 initViewModel()을 호출하는데, 이 시점에서 Fragment가 이미 detach된 상태
